### PR TITLE
Install Oracle Java 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aurora cookbook
 
-Chef cookbook for Apache Aurora
+Chef cookbook for [Apache Aurora](https://aurora.apache.org)
 
 ## Supported Platforms
 
@@ -28,15 +28,15 @@ Include `aurora` in your node's `run_list`:
 
 ### aurora::slave
 
-Include aurora::slave in your mesos slave nodes run_list. You will most likely want to set some attrbibutes (as in, mesos slave attributes) for aurora to use.
+Include `aurora::slave` in your mesos slave node's `run_list`. You will most likely want to set some attributes (as in, mesos slave attributes) for aurora to use.
 
 For example, this might make sense for a cluster on AWS:
 
 ```ruby
-default['mesos']['slave']['attributes']['host'] = node['hostname']
-default['mesos']['slave']['attributes']['rack'] = node['ec2']['placement_availability_zone']
-default['mesos']['slave']['attributes']['instance_id'] = node['ec2']['instance_id']
-default['mesos']['slave']['attributes']['instance_type'] = node['ec2']['instance_type']
+default['mesos']['slave']['flags']['attributes']['host'] = node['hostname']
+default['mesos']['slave']['flags']['attributes']['rack'] = node['ec2']['placement_availability_zone']
+default['mesos']['slave']['flags']['attributes']['instance_id'] = node['ec2']['instance_id']
+default['mesos']['slave']['flags']['attributes']['instance_type'] = node['ec2']['instance_type']
 ```
 
 If you want to enable thermos service announcements to zookeeper, you can set some options **on the scheduler nodes**:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -67,3 +67,8 @@ default['aurora']['use_folsomlabs_apt_repo'] = true
 
 # Is it cool for the scheduler recipe to install java?
 default['aurora']['install_java'] = true
+
+# Aurora 0.9.0 onwards will require Java version 8
+default['java']['install_flavor'] = 'oracle'
+default['java']['jdk_version'] = '8'
+default['java']['oracle']['accept_oracle_download_terms'] = true

--- a/recipes/scheduler.rb
+++ b/recipes/scheduler.rb
@@ -6,7 +6,6 @@
 # Copyright (C) 2014 Folsom Labs
 #
 
-node.default['java']['jdk_version'] = 7
 include_recipe 'java' if node['aurora']['install_java']
 include_recipe 'aurora::apt_repo'
 include_recipe 'mesos::install'


### PR DESCRIPTION
This patch properly sets the Java version attribute, and ensures that the cookbook is forward compatible.
