### PR TITLE
Thermos executor should support something else than ZK announcer

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,6 +48,9 @@ default['aurora']['thermos'] = {
   zk_announce_endpoints: 'localhost:2181',
   zk_announce_path: '/aurora/svc'
 }
+# Other arguments of --thermos_executor_flags can also be passed
+# directly
+default['aurora']['scheduler']['app_config']['thermos_executor_flags'] = ''
 
 default['aurora']['client'] = [
   {

--- a/recipes/_common_scheduler.rb
+++ b/recipes/_common_scheduler.rb
@@ -37,10 +37,10 @@ end
 
 ruby_block 'set thermos_executor flags' do
   block do
-    node.default['aurora']['scheduler']['app_config']['thermos_executor_flags'] =
+    node.default['aurora']['scheduler']['app_config']['thermos_executor_flags'] <<
       if node['aurora']['thermos']['announcer_enable']
         [
-          '--announcer-enable',
+          ' --announcer-enable',
           "--announcer-ensemble=#{node['aurora']['thermos']['zk_announce_endpoints']}",
           "--announcer-serverset-path=#{node['aurora']['thermos']['zk_announce_path']}"
         ].join(' ')


### PR DESCRIPTION
We had the use-case for `--preserve_env` but it could be for everything else.