### PR TITLE
Fix thermos_executor_flags attribute

### DIFF
--- a/recipes/_common_scheduler.rb
+++ b/recipes/_common_scheduler.rb
@@ -37,7 +37,7 @@ end
 
 ruby_block 'set thermos_executor flags' do
   block do
-    node.default['aurora']['scheduler']['app_config']['thermos_executor_flags'] <<
+    node.default['aurora']['scheduler']['app_config']['thermos_executor_flags'] = node['aurora']['scheduler']['app_config']['thermos_executor_flags'] +
       if node['aurora']['thermos']['announcer_enable']
         [
           ' --announcer-enable',


### PR DESCRIPTION
Instead of appending to the string, we triggered an error because of applying
on node object and not on an attribute.

@benley Sorry about that, I broke the repo with my last PR. 